### PR TITLE
Lxdv 44

### DIFF
--- a/src/components/FirstSigninFlow.tsx
+++ b/src/components/FirstSigninFlow.tsx
@@ -1,0 +1,132 @@
+import React, { useState, ChangeEvent } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  IconButton,
+  Box,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { LogoImg } from './LogoImg';
+
+interface SignUpForm {
+  email: string;
+  name: string;
+  verificationCode?: string;
+}
+
+interface FirstSigninFlowProps {
+  isFirstSignIn: boolean;
+  setIsFirstSignIn: (value: boolean) => void;
+}
+
+const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({ isFirstSignIn, setIsFirstSignIn }) => {
+  const [step, setStep] = useState<number>(1);
+  const [formData, setFormData] = useState<SignUpForm>({
+    email: '',
+    name: '',
+    verificationCode: '',
+  });
+
+  const handleClose = () => {
+    setIsFirstSignIn(false);
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prevFormData => ({
+      ...prevFormData,
+      [name]: value,
+    }));
+  };
+
+  const handleNextStep = () => {
+    setStep(prevStep => prevStep + 1);
+  };
+
+  const handlePreviousStep = () => {
+    setStep(prevStep => prevStep - 1);
+  };
+
+  return (
+    <Dialog fullWidth open={isFirstSignIn} onClose={handleClose}>
+      <Box
+        component="section"
+        sx={{ p: 4, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}
+      >
+        <LogoImg Size={60} variant="Dark" />
+      </Box>
+      <DialogTitle
+        sx={{ fontSize: 20, fontWeight: 'bold', textAlign: 'center' }}
+      >
+        {`Step ${step} / 4: ${step === 1 ? 'Enter your Email and Password' : step === 2 ? 'Verify your Email' : step === 3 ? 'Enter your Name' : 'Complete your Sign-Up'}`}
+      </DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={handleClose}
+        sx={{
+          position: 'absolute',
+          right: 8,
+          top: 8,
+          color: theme => theme.palette.grey[500],
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+      <DialogContent>
+        {step === 1 && (
+          <>
+            <TextField
+              fullWidth
+              margin="normal"
+              type="email"
+              name="email"
+              label="Email"
+              value={formData.email}
+              onChange={handleChange}
+            />
+            <TextField
+              fullWidth
+              margin="normal"
+              type="password"
+              name="password"
+              label="Password"
+            />
+          </>
+        )}
+        {step === 2 && (
+          <TextField
+            fullWidth
+            margin="normal"
+            type="text"
+            name="verificationCode"
+            label="Verification Code"
+            value={formData.verificationCode}
+            onChange={handleChange}
+          />
+        )}
+        {step === 3 && (
+          <TextField
+            fullWidth
+            margin="normal"
+            type="text"
+            name="name"
+            label="Full Name"
+            value={formData.name}
+            onChange={handleChange}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        {step > 1 && <Button onClick={handlePreviousStep}>Back</Button>}
+        {step < 4 && <Button onClick={handleNextStep}>Next</Button>}
+        {step === 4 && <Button onClick={handleClose}>Complete Sign-Up</Button>}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default FirstSigninFlow;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,25 @@
-import { Page } from "../components/layout/Page"
-import FirmSearch from "../components/FirmSearch";
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import { Page } from '../components/layout/Page';
+import FirmSearch from '../components/FirmSearch';
+import FirstSigninFlow from '../components/FirstSigninFlow';
 
+const Home: React.FC = () => {
+  const [isFirstSignIn, setIsFirstSignIn] = useState<boolean>(true);
 
-const Home = () => {
+  const handleTestClick = () => {
+    setIsFirstSignIn(true);
+  };
+
   return (
     <Page>
-        {/* FirmSearch Component */}
-        <div style={{ margin: '20px 0' }}>
-            <FirmSearch />
-        </div>
+      <div style={{ margin: '20px 0' }}>
+        <FirmSearch />
+      </div>
+      <FirstSigninFlow isFirstSignIn={isFirstSignIn} setIsFirstSignIn={setIsFirstSignIn} />
+      <Button onClick={handleTestClick}>Test</Button>
     </Page>
-  )
-}
+  );
+};
 
-export default Home
+export default Home;

--- a/src/pages/Sign-in.tsx
+++ b/src/pages/Sign-in.tsx
@@ -1,24 +1,20 @@
-import { SignIn } from "@clerk/clerk-react"
-import React from "react"
-import { Page } from "../components/layout/Page"
+import { SignIn } from "@clerk/clerk-react";
+import React from "react";
+import { Page } from "../components/layout/Page";
 
 
 const Signin: React.FC = () => {
   return (
-    <Page >
-        <SignIn 
-    appearance={{
-      variables: {
-      
-        borderRadius: "8px",   
-     
-      },
-      
-    }}
-  
-  />
-  </Page>
-  )
-}
+    <Page>
+      <SignIn
+        appearance={{
+          variables: {
+            borderRadius: "8px",
+          }
+        }}
+      />
+    </Page>
+  );
+};
 
-export default Signin
+export default Signin;

--- a/src/pages/UnauthedDashboard.tsx
+++ b/src/pages/UnauthedDashboard.tsx
@@ -7,8 +7,6 @@ export const UnauthedDashboard = () => {
     <Page>
       <Typography>Please sign in to view this page.</Typography>
       <Link to="/sign-in">Sign In</Link>
-      <Link to="/sign-up">Sign Up</Link>
-
-    </Page>
+      </Page>
   )
 }


### PR DESCRIPTION
📝 Description
This PR addresses LXDV-44, introducing the FirstSignInFlow component to present the Lexter Lens Quickstart flow to first-time users. The purpose is to guide lawyers with claimed accounts through their initial sign-in by allowing them to input their username and tags of interest. The Sign-Up link has been removed from the Sign In/Sign Up page to streamline the process.

🔍 Related Issue(s)
Closes LXDV-44 (Add Quickstart Flow for First-Time Sign-In)
Implements requirements from LDDV-30 (Quickstart Modal Design).
🚀 Changes Made
✅ Implemented the FirstSignInFlow component for presenting Quickstart modals to first-time users.
✅ Removed the Sign-Up link from the Sign In/Sign Up page to focus on the Quickstart flow for claimed accounts.
🔄 Refactored sign-in logic to integrate Quickstart flow based on first-time user status.

How to Test
Checkout this branch: git checkout LXDV-44
Start the application: npm run dev

✅ Checklist
 My code follows the project’s coding style.
 I have tested my changes locally.
 
 Video link : [Screencast from 2025-01-09 21-23-42.webm](https://github.com/user-attachments/assets/086817d9-ccc9-4d52-bbf3-9878f7bbb8b2)

