### PR TITLE
Lxdv 33

### DIFF
--- a/src/components/FirstSigninFlow.tsx
+++ b/src/components/FirstSigninFlow.tsx
@@ -14,6 +14,8 @@ import {
 import CloseIcon from '@mui/icons-material/Close'
 import { LogoImg } from './LogoImg'
 import { useLawyer } from '../lib/contexts/LawyerContext'
+import Checkbox from '@mui/material/Checkbox';
+
 
 interface FirstSigninFlowProps {
   isFirstSignIn: boolean
@@ -106,6 +108,8 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
               value={formData.userName}
               onChange={handleChange}
             />
+             
+             <Checkbox/>Privacy on Lexter
           </>
         )}
         {step === 2 && (

--- a/src/components/FirstSigninFlow.tsx
+++ b/src/components/FirstSigninFlow.tsx
@@ -1,25 +1,24 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react';
 import {
+  Box,
+  Button,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
-  TextField,
-  Button,
   IconButton,
-  Box,
   Link,
+  TextField,
   Typography,
-} from '@mui/material'
-import CloseIcon from '@mui/icons-material/Close'
-import { LogoImg } from './LogoImg'
-import { useLawyer } from '../lib/contexts/LawyerContext'
-import Checkbox from '@mui/material/Checkbox';
-
+  Checkbox,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { LogoImg } from './LogoImg';
+import { useLawyer } from '../lib/contexts/LawyerContext';
 
 interface FirstSigninFlowProps {
-  isFirstSignIn: boolean
-  setIsFirstSignIn: (value: boolean) => void
+  isFirstSignIn: boolean;
+  setIsFirstSignIn: (value: boolean) => void;
 }
 
 const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
@@ -27,30 +26,33 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
   setIsFirstSignIn,
 }) => {
   const { email, firstName, userName, phone, handleUpdateUser, handleChange } =
-    useLawyer()
+    useLawyer();
 
-  const [step, setStep] = useState<number>(1)
+  const [step, setStep] = useState<number>(1);
+  const [isPrivacyPolicyOpen, setIsPrivacyPolicyOpen] = useState(false); // New state for privacy policy dialog
+
   const [formData, setFormData] = useState({
     email,
     firstName,
     userName,
     phone,
-  })
+  });
+
   useEffect(() => {
     setFormData({
       email,
       firstName: firstName || '',
       userName: userName || '',
       phone: phone || '',
-    })
-  }, [email, firstName, userName, phone])
-  console.log(formData)
-  const handleClose = () => setIsFirstSignIn(false)
-  const handleNextStep = () => setStep((prevStep) => prevStep + 1)
-  const handlePreviousStep = () => setStep((prevStep) => prevStep - 1)
+    });
+  }, [email, firstName, userName, phone]);
+
+  const handleClose = () => setIsFirstSignIn(false);
+  const handleNextStep = () => setStep((prevStep) => prevStep + 1);
+  const handlePreviousStep = () => setStep((prevStep) => prevStep - 1);
 
   return (
-    <Dialog fullWidth open={isFirstSignIn} onClose={handleClose} >
+    <Dialog fullWidth open={isFirstSignIn} onClose={handleClose}>
       <Box
         component="section"
         sx={{
@@ -62,7 +64,7 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
           minHeight: '85px',
         }}
       >
-        <LogoImg variant="Dark" Size={60}  />
+        <LogoImg variant="Dark" Size={60} />
       </Box>
       <DialogTitle
         sx={{ fontSize: 20, fontWeight: 'bold', textAlign: 'center' }}
@@ -70,10 +72,10 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
         {step === 1
           ? 'Lexter Lens Quickstart'
           : step === 2
-            ? `Let's Make Lexter Lens Relevant to You`
-            : step === 3
-              ? 'Make the Legal World More Transparent'
-              : 'Completed'}
+          ? `Let's Make Lexter Lens Relevant to You`
+          : step === 3
+          ? 'Make the Legal World More Transparent'
+          : 'Completed'}
       </DialogTitle>
       <IconButton
         aria-label="close"
@@ -108,8 +110,27 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
               value={formData.userName}
               onChange={handleChange}
             />
-             
-             <Checkbox/>Privacy on Lexter
+
+            <Checkbox /> Privacy on Lexter
+            <ul>
+              <li>Line about privacy here, leave room for now (no profiles)</li>
+              <li>Line about privacy here, leave room for now (privacy matters)</li>
+              <li>
+                Line about nobody seeing your tags, interests, followed threads
+              </li>
+              <li>
+                <Link
+                  onClick={() => setIsPrivacyPolicyOpen(true)} // Open the modal
+                  sx={{
+                    color: 'primary.main',
+                    cursor: 'pointer',
+                    textDecoration: 'underline',
+                  }}
+                >
+                  Lawlink
+                </Link>
+              </li>
+            </ul>
           </>
         )}
         {step === 2 && (
@@ -153,17 +174,43 @@ const FirstSigninFlow: React.FC<FirstSigninFlowProps> = ({
           </Button>
         )}
         {step === 4 && (
-
-          <Button sx={{ fontWeight: 'bold' }} onClick={() => {
-            handleUpdateUser(); 
-            handleClose(); 
-          }}>
+          <Button
+            sx={{ fontWeight: 'bold' }}
+            onClick={() => {
+              handleUpdateUser();
+              handleClose();
+            }}
+          >
             Complete Sign-Up
           </Button>
         )}
       </DialogActions>
-    </Dialog>
-  )
-}
 
-export default FirstSigninFlow
+      {/* Privacy Policy Dialog */}
+      <Dialog
+        open={isPrivacyPolicyOpen}
+        onClose={() => setIsPrivacyPolicyOpen(false)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>Privacy Policy</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            This is where you can place the full privacy policy content. Keep it
+            detailed and user-friendly.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setIsPrivacyPolicyOpen(false)}
+            sx={{ fontWeight: 'bold' }}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Dialog>
+  );
+};
+
+export default FirstSigninFlow;


### PR DESCRIPTION
Showcasing the Privacy on Quickstart flow Progress Step  1/3

Display "Privacy on Lexter Lens" subheading

Display 3 bullet points with filler text "Privacy - filler text for now."

Potentially adding a link to the full privacy policy for Lexter (aiming to keep users focused on this flow, and avoid having the users leave this page and not completing this first time sign in flow)